### PR TITLE
Color user-selected routes

### DIFF
--- a/jodeln/gui/od_tablemodel.py
+++ b/jodeln/gui/od_tablemodel.py
@@ -3,23 +3,25 @@
 from PySide2 import QtCore
 from PySide2.QtCore import Qt
 
+from typing import List
+from model import RouteInfo
 
 class ODTableModel(QtCore.QAbstractTableModel):
     """Model for showing a table of OD routes."""
-    def __init__(self, data):
+    def __init__(self, route_data):
         super(ODTableModel, self).__init__()
-        self._data = data
+        self._data = route_data # type: List[RouteInfo]
 
     def data(self, index, role):
         if role == Qt.DisplayRole:
             if index.column() == 0:
-                return self._data[index.row()]['o_name']
+                return self._data[index.row()].o_name
             if index.column() == 1:
-                return self._data[index.row()]['d_name']
+                return self._data[index.row()].d_name
             if index.column() == 2:
-                return self._data[index.row()]['route']
+                return self._data[index.row()].name
             if index.column() == 3:
-                return str(self._data[index.row()]['nodes'])
+                return str(self._data[index.row()].nodes)
 
     def rowCount(self, index):
         return len(self._data)
@@ -39,7 +41,7 @@ class ODTableModel(QtCore.QAbstractTableModel):
             if section == 3:
                 return "Nodes"
 
-    def get_routes_from_OD(self, index):
+    def get_route_at_index(self, index):
         """Return routes for the OD at the selected index."""
-        od = self._data[index.row()]
-        return (od['origin'], od['destination'], od['route'])
+        route = self._data[index.row()]
+        return (route.origin, route.destination, route.name)

--- a/jodeln/gui/schematic_items.py
+++ b/jodeln/gui/schematic_items.py
@@ -1,0 +1,56 @@
+from PySide2.QtWidgets import QGraphicsItem
+from PySide2.QtCore import QRectF
+from typing import Optional
+
+from PySide2.QtGui import QPainter, QPen, QColor
+from PySide2.QtWidgets import QStyleOptionGraphicsItem, QWidget
+
+
+class LinkItem(QGraphicsItem):
+    """GraphicsItem for network links.
+    
+    Displayed as a line between the starting node i and ending node j of the link.
+    """
+    def __init__(self, ix, iy, jx, jy, parent: Optional[QGraphicsItem] = None) -> None:
+        super().__init__(parent=parent)
+        self.ix = ix
+        self.iy = iy
+        self.jx = jx
+        self.jy = jy
+
+        self.topleft_x = min(ix, iy)
+        self.topleft_y = min(iy, jy)
+        self.width = abs(ix - jx)
+        self.height = abs(iy - jy)
+
+        self.is_on_selected_path = False
+    
+    def boundingRect(self) -> QRectF:
+        return QRectF(self.topleft_x, self.topleft_y, self.width, self.height)
+
+    def paint(self, painter: QPainter, option: QStyleOptionGraphicsItem, widget: Optional[QWidget]) -> None:
+        if self.is_on_selected_path:
+            pen = QPen(QColor("green"), 2)
+            painter.setPen(pen)
+            painter.drawLine(self.ix, self.iy, self.jx, self.jy)
+        else:
+            painter.drawLine(self.ix, self.iy, self.jx, self.jy)
+
+
+class NodeItem(QGraphicsItem):
+    """GraphicsItem for network nodes.
+    
+    Displayed as a circle at the node xy coordinate.
+    """
+    def __init__(self, x, y, parent: Optional[QGraphicsItem] = None) -> None:
+        super().__init__(parent=parent)
+        self.x = x
+        self.y = y
+    
+    def boundingRect(self) -> QRectF:
+        penWidth = 1
+        return QRectF((self.x - 2) - penWidth / 2, (self.y - 2) - penWidth / 2,
+                      (self.x + 4) + penWidth, (self.y + 4) + penWidth)
+
+    def paint(self, painter: QPainter, option: QStyleOptionGraphicsItem, widget: Optional[QWidget]) -> None:
+        painter.drawEllipse(self.x - 2, self.y - 2, 4, 4)

--- a/jodeln/gui/schematic_scene.py
+++ b/jodeln/gui/schematic_scene.py
@@ -1,14 +1,83 @@
 from PySide2.QtWidgets import QGraphicsScene
+from .schematic_items import LinkItem, NodeItem
 
 from typing import TYPE_CHECKING
+from typing import List
+from model import RouteInfo
 
 if TYPE_CHECKING:
-    import PySide2.QtWidgets
+    import PySide2.QtWidgets    
+
 
 
 class SchematicScene(QGraphicsScene):
+    """QGraphicsScene for displaying the network.
+
+    Attributes
+    ----------
+    links : Dict
+        Stores a LinkItem for each link in the network.
+        Keyed by: (start node id, end node id)
+    routes: Dict
+        Stores the nodes along each route.
+        Keyed by: (route.origin, route.destination, route.name) 
+    """
+    
     def __init__(self):
         super(SchematicScene, self).__init__()
+        self.links = {}
+        self.routes = {}
+
+    def load_network(self, nodes, links):
+        """Transfer network node and link data from the Model to the SchematicScene. 
+
+        Parameters
+        ----------
+        nodes : Dict
+            {i: (x, y)} Dict of coordinates for each node.
+        links : List
+            [(i, j), ...] List of start/end node numbers for each link.
+        """
+        for _, (x, y) in nodes.items():
+            self.addItem(NodeItem(x, y))
+        
+        for (i, j) in links:
+            self.links[(i, j)] = LinkItem(nodes[i][0],
+                                          nodes[i][1],
+                                          nodes[j][0],
+                                          nodes[j][1])
+
+            self.addItem(self.links[(i, j)])
+
+    def load_routes(self, routes: List[RouteInfo]):
+        """Transfers data about the routes and od from the Model to the SchematicScene.
+
+        Parameters
+        ----------
+        routes : List[RouteInfo]
+            Basic info about the route for each OD. 
+            Includes route origin, destination, route name, and nodes.
+        """
+        for route in routes:
+            self.routes[(route.origin, route.destination, route.name)] = route.nodes
+
+    def color_route(self, route, is_selected):
+        """Sets a bool to indicate if the link is on the user-selected path.
+
+        LinkItem objects in the scene can update themselves to be colored based
+        on the selection bool.
+
+        Parameters
+        ----------
+        route : Tuple
+            Route identifier tuple: (route.origin, route.destination, route.name)
+        is_selected : bool
+            True if the the link is on the user selected path.
+        """
+        for x in range(len(self.routes[route]) - 1):
+            i = self.routes[route][x]
+            j = self.routes[route][x + 1]
+            self.links[(i, j)].is_on_selected_path = is_selected
 
     def mousePressEvent(self, event: 'PySide2.QtWidgets.QGraphicsSceneMouseEvent') -> None:
         return super().mousePressEvent(event)

--- a/jodeln/main.py
+++ b/jodeln/main.py
@@ -56,8 +56,8 @@ class MainWindow(QMainWindow):
         if load_successful:
             self.draw_network()
 
-            od_data = self.model.get_od_data()
-            self.od_table_model = od_tablemodel.ODTableModel(od_data)
+            routes = self.model.get_route_list()
+            self.od_table_model = od_tablemodel.ODTableModel(routes)
             self.ui.tblOD.setModel(self.od_table_model)
             self.ui.tblOD.selectionModel().selectionChanged.connect(self.on_od_table_selection)
 

--- a/jodeln/main.py
+++ b/jodeln/main.py
@@ -4,6 +4,7 @@ from PySide2.QtWidgets import QApplication, QMainWindow
 from PySide2.QtCore import QFile
 from PySide2.QtGui import QDoubleValidator
 from PySide2 import QtUiTools
+from PySide2.QtWidgets import QAbstractItemView
 from gui.ui_mainwindow import Ui_MainWindow
 
 from gui import schematic_scene
@@ -44,6 +45,9 @@ class MainWindow(QMainWindow):
         # Setup graphics view
         self.schematic_scene = schematic_scene.SchematicScene()
         self.ui.gvSchematic.setScene(self.schematic_scene)
+
+        # Set table behaviors
+        self.ui.tblOD.setSelectionBehavior(QAbstractItemView.SelectRows)
 
         
     def load(self):

--- a/jodeln/model.py
+++ b/jodeln/model.py
@@ -149,12 +149,14 @@ class Model():
         net_write.export_route_list(self.net, output_folder)
 
     def get_node_xy(self):
+        """Return xy coordinates for each node."""
         if not self.net:
             return
         
         return {i: (node.x, node.y) for i, node in self.net.nodes.items()}
 
-    def get_links(self):
+    def get_link_end_ids(self):
+        """Return node ids for the start and end of each link."""
         if not self.net:
             return
         

--- a/jodeln/model.py
+++ b/jodeln/model.py
@@ -2,6 +2,8 @@
 """
 
 import os
+from dataclasses import dataclass
+from typing import List
 
 from network import net_read
 from network import net_write
@@ -9,6 +11,17 @@ from network import net_write
 from od import od_read
 from od import od_write
 from od import od_estimation as odme
+
+
+@dataclass
+class RouteInfo:
+    """Basic OD information for a route."""
+    origin: int
+    destination: int
+    o_name: str
+    d_name: str
+    name: str
+    nodes: List
 
 
 class Model():
@@ -147,28 +160,25 @@ class Model():
         
         return [(i, j) for i, j, _ in self.net.links()]
 
-    def get_od_data(self):
-        """Return basic info OD for each od route.
-        """
-        od_data = []
+    def get_route_list(self):
+        """Return basic OD information for each route."""
+        routes = [] # type: List[RouteInfo]
         
         for od in self.net.od:
             o_name = self.net.nodes[od.origin].name
             d_name = self.net.nodes[od.destination].name
 
             for route in od.routes:
-                basic_info = {
-                    'origin': od.origin,
-                    'destination': od.destination,
-                    'o_name': o_name,
-                    'd_name': d_name,
-                    'route': route.name,
-                    'nodes': route.nodes
-                    }
+                basic_info = RouteInfo(od.origin, 
+                                       od.destination, 
+                                       o_name,
+                                       d_name,
+                                       route.name,
+                                       route.nodes)
 
-                od_data.append(basic_info)
+                routes.append(basic_info)
 
-        return od_data
+        return routes
 
 
 def _clean_file_path(file_path):


### PR DESCRIPTION
This pull request implements custom QGraphicsItems to draw the network. This allows logic to be added, such as coloring the network based on the route selected in the route table. 

A few helper commits are included to cleanup code for the interaction between the route table and schematic scene (3c873ff, 38f79ed, dab87d0).

Commit 5d4b134 implements the custom QGraphicsitems and moves the network drawing code to the schematic scene.
