### PR TITLE
Implement export folder button

### DIFF
--- a/jodeln/gui/mainwindow.ui
+++ b/jodeln/gui/mainwindow.ui
@@ -80,17 +80,10 @@
       <property name="verticalSpacing">
        <number>6</number>
       </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Export Folder</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QLineEdit" name="leExportFolder"/>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <layout class="QGridLayout" name="gridLayout">
         <item row="1" column="0">
          <widget class="QPushButton" name="pbExportTurns">
@@ -211,6 +204,13 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="pbExportFolder">
+        <property name="text">
+         <string>Export Folder</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </item>

--- a/jodeln/gui/ui_mainwindow.py
+++ b/jodeln/gui/ui_mainwindow.py
@@ -63,15 +63,10 @@ class Ui_MainWindow(object):
         self.formLayout_2.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
         self.formLayout_2.setLabelAlignment(Qt.AlignRight|Qt.AlignTrailing|Qt.AlignVCenter)
         self.formLayout_2.setVerticalSpacing(6)
-        self.label_6 = QLabel(self.centralwidget)
-        self.label_6.setObjectName(u"label_6")
-
-        self.formLayout_2.setWidget(0, QFormLayout.LabelRole, self.label_6)
-
         self.leExportFolder = QLineEdit(self.centralwidget)
         self.leExportFolder.setObjectName(u"leExportFolder")
 
-        self.formLayout_2.setWidget(0, QFormLayout.FieldRole, self.leExportFolder)
+        self.formLayout_2.setWidget(1, QFormLayout.FieldRole, self.leExportFolder)
 
         self.gridLayout = QGridLayout()
         self.gridLayout.setObjectName(u"gridLayout")
@@ -158,7 +153,12 @@ class Ui_MainWindow(object):
         self.gridLayout.addWidget(self.pbEstimateOD, 3, 0, 1, 1)
 
 
-        self.formLayout_2.setLayout(1, QFormLayout.FieldRole, self.gridLayout)
+        self.formLayout_2.setLayout(2, QFormLayout.FieldRole, self.gridLayout)
+
+        self.pbExportFolder = QPushButton(self.centralwidget)
+        self.pbExportFolder.setObjectName(u"pbExportFolder")
+
+        self.formLayout_2.setWidget(1, QFormLayout.LabelRole, self.pbExportFolder)
 
 
         self.verticalLayout.addLayout(self.formLayout_2)
@@ -209,7 +209,6 @@ class Ui_MainWindow(object):
     def retranslateUi(self, MainWindow):
         MainWindow.setWindowTitle(QCoreApplication.translate("MainWindow", u"Jodeln", None))
         self.pbShowDialogOpen.setText(QCoreApplication.translate("MainWindow", u"Open", None))
-        self.label_6.setText(QCoreApplication.translate("MainWindow", u"Export Folder", None))
 #if QT_CONFIG(tooltip)
         self.pbExportTurns.setToolTip("")
 #endif // QT_CONFIG(tooltip)
@@ -224,5 +223,6 @@ class Ui_MainWindow(object):
         self.leWeightRouteRatio.setText(QCoreApplication.translate("MainWindow", u"1", None))
         self.pbExportRoutes.setText(QCoreApplication.translate("MainWindow", u"Export List of Routes", None))
         self.pbEstimateOD.setText(QCoreApplication.translate("MainWindow", u"Estimate and Export OD", None))
+        self.pbExportFolder.setText(QCoreApplication.translate("MainWindow", u"Export Folder", None))
     # retranslateUi
 

--- a/jodeln/main.py
+++ b/jodeln/main.py
@@ -89,7 +89,7 @@ class MainWindow(QMainWindow):
 
         # Connect push buttons to slot functions
         self.ui.pbShowDialogOpen.clicked.connect(self.show_dialog_open)
-        #self.ui.pbLoad.clicked.connect(self.load)
+        self.ui.pbExportFolder.clicked.connect(self.on_pbExportFolder_click)
         self.ui.pbExportTurns.clicked.connect(self.export_turns)
         self.ui.pbExportRoutes.clicked.connect(self.export_routes)
         self.ui.pbExportLinksAndTurnsByOD.clicked.connect(self.export_links_and_turns_by_od)
@@ -141,6 +141,15 @@ class MainWindow(QMainWindow):
             self.ui.tblOD.selectionModel().selectionChanged.connect(self.on_od_table_selection)
 
             self.schematic_scene.load_routes(routes)
+
+    def on_pbExportFolder_click(self) -> None:
+        """Open a standard file dialog for selecting the export folder."""
+        export_folder = QFileDialog.getExistingDirectory(
+            self, "Select Export Folder", 
+            "",
+            options=QFileDialog.ShowDirsOnly | QFileDialog.DontResolveSymlinks)
+
+        self.ui.leExportFolder.setText(export_folder)
 
     def export_turns(self) -> None:
         """Export turns to csv."""


### PR DESCRIPTION
Adds an export folder button to the main window. This makes the main window GUI consistent with the dialog for opening network files. Closes #17