### PR TITLE
Remove nodes column that was for debugging

### DIFF
--- a/jodeln/gui/od_tablemodel.py
+++ b/jodeln/gui/od_tablemodel.py
@@ -20,14 +20,12 @@ class ODTableModel(QtCore.QAbstractTableModel):
                 return self._data[index.row()].d_name
             if index.column() == 2:
                 return self._data[index.row()].name
-            if index.column() == 3:
-                return str(self._data[index.row()].nodes)
 
     def rowCount(self, index):
         return len(self._data)
 
     def columnCount(self, index):
-        return 4
+        return 3
 
     def headerData(self, section: int, orientation: Qt.Orientation, role: int):
         """Get Table header names."""
@@ -38,8 +36,6 @@ class ODTableModel(QtCore.QAbstractTableModel):
                 return "Destination"
             if section == 2:
                 return "Route Name"
-            if section == 3:
-                return "Nodes"
 
     def get_route_at_index(self, index):
         """Return routes for the OD at the selected index."""


### PR DESCRIPTION
The GUI contains a table listing all routes in the model. The column containing the route nodes was removed because it is no longer needed. 

The column showed the internal index of each node in sequence along the route, such as [0, 2, 4, 6]. Listing the internal index was useful for debugging purposes, but is not useful for end-users.