### PR TITLE
Update NetNode init parameters

### DIFF
--- a/jodeln/network/net.py
+++ b/jodeln/network/net.py
@@ -140,6 +140,18 @@ class TurnData():
     geh: float
 
 
+@dataclass
+class NodeParameters():
+    """Parameters needed for constructing a NetNode object.
+    """
+    __slots__ = ['name', 'x', 'y', 'is_origin', 'is_destination']
+    name: str
+    x: float
+    y: float
+    is_origin: bool
+    is_destination: bool
+
+
 class NetNode():
     """A point (junction) in the network graph.
 
@@ -150,8 +162,8 @@ class NetNode():
     ----------
     key : int
         Unique identifier for the node.
-    payload : List
-        List of data to assign to the node.
+    name : str
+        Name, or label, for the node.
     x : float
         x-coordinate of node. Defaults to zero.
     y : float
@@ -165,34 +177,23 @@ class NetNode():
     up_neighbors : list
         Upstream node IDs connected to this node.
     """
-    def __init__(self, key, payload):
+    def __init__(self, key, parameters: NodeParameters):
         """Create a node in the network graph.
 
         Parameters
         ----------
         key : int
             Unique identifier.
-        payload : List
-            Data about the node. TODO: remove payload, everything in the payload
-            should be saved as an instance attribute (self.name, self.x, ...etc)
+        parameters : NodeParameters
+            Data about the node. Name, x,y coordinates, etc.
         """
         self.key = key
-        self.payload = payload
         
-        self.name = payload[0]
-        
-        try:
-            self.x = float(payload[1])
-        except ValueError:
-            self.x = 0
-        
-        try:
-            self.y = float(payload[2])
-        except ValueError:
-            self.y = 0
-        
-        self.is_origin = int(payload[3]) == 1
-        self.is_destination = int(payload[4]) == 1
+        self.name = parameters.name
+        self.x = parameters.x
+        self.y = parameters.y
+        self.is_origin = parameters.is_origin
+        self.is_destination = parameters.is_destination
 
         self.neighbors = {} # type: Dict[int, NetLinkData]
         self.up_neighbors = []
@@ -247,16 +248,16 @@ class Network():
         self.od = [] # type: List[NetODpair]
         self.total_geh = 0
 
-    def add_node(self, payload) -> None:
+    def add_node(self, parameters: NodeParameters) -> None:
         """Add a node to the network graph.
 
         Parameters
         ----------
-        payload : List
-            List of data belonging to the node.
+        parameters : NodeParameters
+            Data about the node. Name, x,y coordinates, etc.
         """
         key = len(self.nodes)
-        self.nodes[key] = NetNode(key, payload)
+        self.nodes[key] = NetNode(key, parameters)
 
     def add_link(self, i_name, j_name, payload) -> None:
         """Connects two nodes to form an link in the network graph.

--- a/jodeln/network/net_read.py
+++ b/jodeln/network/net_read.py
@@ -14,7 +14,7 @@ but a separate Factory module (this file) seems more flexible.
 """
 
 import csv
-from .net import Network, NetRoute
+from .net import Network, NetRoute, NodeParameters
 
 
 def from_node_link_csv(node_csv, link_csv):
@@ -54,11 +54,37 @@ def from_node_link_csv(node_csv, link_csv):
 
     net = Network()
 
-    with open(node_csv, newline='') as f:
-        reader = csv.reader(f)
+    with open(node_csv, newline='') as file:
+        reader = csv.reader(file)
+
+        # skip header
         next(reader)
-        for node_payload in reader:
-            net.add_node(node_payload)
+
+        for payload in reader:
+            node_name = payload[0]
+            
+            try:
+                node_x = float(payload[1])
+            except ValueError:
+                node_x = 0
+            
+            try:
+                node_y = float(payload[2])
+            except ValueError:
+                node_y = 0
+            
+            node_is_origin = int(payload[3]) == 1
+            node_is_destination = int(payload[4]) == 1
+
+            node_parameters = NodeParameters(
+                name=node_name,
+                x=node_x,
+                y=node_y,
+                is_origin=node_is_origin,
+                is_destination=node_is_destination
+            )
+
+            net.add_node(node_parameters)
 
     with open(link_csv, newline='') as f:
         reader = csv.reader(f)


### PR DESCRIPTION
Consolidate NetNode init parameters into a NodeParameters dataclass to help with type hints and intellisense. Move type conversion responsibility to net_read.py. Moving type conversion responsibility allows the code to be more flexible if other import formats are allowed beyond csv. Each import function can be responsible for converting data to NodeParameters.