### PR TITLE
Update Network add_link parameters

### DIFF
--- a/jodeln/network/net.py
+++ b/jodeln/network/net.py
@@ -77,6 +77,15 @@ class NetODpair():
     est_total_volume: float
     routes: List[NetRoute]
 
+@dataclass
+class LinkParameters():
+    """Parameters needed for constructing a NetLinkData object.
+    """
+    __slots__ = ['name', 'cost', 'target_volume']
+    name: str
+    cost: float
+    target_volume: float
+
 
 @dataclass
 class NetLinkData():
@@ -259,7 +268,7 @@ class Network():
         key = len(self.nodes)
         self.nodes[key] = NetNode(key, parameters)
 
-    def add_link(self, i_name, j_name, payload) -> None:
+    def add_link(self, i_name, j_name, parameters: LinkParameters) -> None:
         """Connects two nodes to form an link in the network graph.
 
         Parameters
@@ -268,19 +277,20 @@ class Network():
             Origin node name
         j_name : str
             Destination node name
-        payload : List
-            Data belonging to the link. See NetLinkData class.
+        parameters : LinkParameters
+            Data belonging to the link. Name, cost, etc.
         """
         i_key, _ = self.get_node_by_name(i_name) 
         j_key, _ = self.get_node_by_name(j_name) 
         
-        link_data = NetLinkData(cost=float(payload[0]), 
-                             name=payload[1],
-                             target_volume=float(payload[2]),
-                             link_index=self.n_links,
-                             assigned_volume=0,
-                             geh=0,
-                             seed_volume=0)
+        link_data = NetLinkData(
+            cost=parameters.cost, 
+            name=parameters.name,
+            target_volume=parameters.target_volume,
+            link_index=self.n_links,
+            assigned_volume=0,
+            geh=0,
+            seed_volume=0)
 
         self.nodes[i_key].add_neighbor(j_key, link_data)
         self.n_links += 1

--- a/jodeln/network/net_read.py
+++ b/jodeln/network/net_read.py
@@ -14,7 +14,7 @@ but a separate Factory module (this file) seems more flexible.
 """
 
 import csv
-from .net import Network, NetRoute, NodeParameters
+from .net import Network, NetRoute, NodeParameters, LinkParameters
 
 
 def from_node_link_csv(node_csv, link_csv):
@@ -86,12 +86,34 @@ def from_node_link_csv(node_csv, link_csv):
 
             net.add_node(node_parameters)
 
-    with open(link_csv, newline='') as f:
-        reader = csv.reader(f)
+    with open(link_csv, newline='') as file:
+        reader = csv.reader(file)
+        
+        # skip header
         next(reader)
-        for row in reader:
-            i_name, j_name, *payload = row
-            net.add_link(i_name, j_name, payload)
+        
+        for payload in reader:
+            i_name = payload[0]
+            j_name = payload[1]
+            
+            try:
+                link_cost = float(payload[2])
+            except ValueError:
+                link_cost = 0
+            
+            try:
+                link_target_volume = float(payload[4])
+            except ValueError:
+                link_target_volume = 0
+
+
+            link_parameters = LinkParameters(
+                name=payload[3],
+                cost=link_cost,
+                target_volume=link_target_volume
+            )
+            
+            net.add_link(i_name, j_name, link_parameters)
 
     net.init_turns()
     net.init_routes()


### PR DESCRIPTION
Update for consistency with NetNode init parameters (#26).

Consolidate add_link parameters into a LinkParameters dataclass to help with type hints and intellisense. Move type conversion responsibility to net_read.py. Moving type conversion responsibility allows the code to be more flexible if other import formats are allowed beyond csv. Each import function can be responsible for converting data to LinkParameters.