### PR TITLE
Decouple OD matrix objects from network object

### DIFF
--- a/jodeln/network/net.py
+++ b/jodeln/network/net.py
@@ -30,7 +30,7 @@ class Network():
         nodes within the Network graph.
     turns : Dict[int, TurnData]
         Turns within the Network graph.
-    od : List[NetODpair]
+    od_pairs : List[NetODpair]
         OD data for the network.
     total_geh : float
         Grand total of summing all the GEH values of the links and turns. 
@@ -39,12 +39,12 @@ class Network():
         Scalar to convert node x,y position to real-world coordinates. Required
         to ensure the network is displayed legibly in the GUI.
     """
-    __slots__ = ['_graph', '_turns', 'n_links', 'od', 'total_geh', 'coord_scale']
+    __slots__ = ['_graph', '_turns', 'n_links', 'od_pairs', 'total_geh', 'coord_scale']
 
     def __init__(self):
         self._graph: dict[int, NetNode] = {}
         self._turns: dict[tuple[int, int, int], TurnData] = {}
-        self.od: list[NetODpair] = []
+        self.od_pairs: list[NetODpair] = []
         self.total_geh: float = 0
         self.coord_scale: float = 1
 
@@ -159,13 +159,11 @@ class Network():
                 if len(node_seq) == 0:
                     continue
                 
-                od = NetODpair(
-                        origin=i,
-                        destination=j, 
-                        seed_total_volume=0, 
-                        est_total_volume=0, 
-                        routes=[NetRoute(nodes=node_seq, name="")])
-                self.od.append(od)
+                od_pair = NetODpair(
+                            origin=i,
+                            destination=j, 
+                            routes=[NetRoute(nodes=node_seq, name="")])
+                self.od_pairs.append(od_pair)
         
         # Update route names
         self.set_route_names()
@@ -209,9 +207,8 @@ class Network():
         od_mat : Dict
             OD matrix, imported from csv. See od_read.py.
         """
-        for od in self.od:
+        for od in self.od_pairs:
             od_volume = od_mat[(od.origin, od.destination)]
-            od.seed_total_volume = od_volume
             for route in od.routes:
                 route.seed_volume = od_volume * route.target_ratio
                 route.assigned_volume = route.seed_volume
@@ -234,7 +231,7 @@ class Network():
             t.assigned_volume = 0
         
         # assign link & turn volumes
-        for od in self.od:
+        for od in self.od_pairs:
             for route in od.routes:
                 n_route_nodes = len(route.nodes)
                 
@@ -270,7 +267,7 @@ class Network():
         unique to their respective routes.
         """
         
-        for od in self.od:
+        for od in self.od_pairs:
             # gather all the links on all routes from o to d
             od_links = []
             for route in od.routes:

--- a/jodeln/network/net_read.py
+++ b/jodeln/network/net_read.py
@@ -338,7 +338,7 @@ def import_routes(route_csv, net: Network) -> None:
             user_ratio = float(user_ratio)
             node_seq = [net.get_node_by_name(v)[0] for v in user_seq]
 
-            for od in net.od:
+            for od in net.od_pairs:
                 if not (od.origin == origin and od.destination == destination):
                     continue
                 
@@ -356,7 +356,7 @@ def import_routes(route_csv, net: Network) -> None:
                         assigned_ratio=0))
 
         # Normalize target_ratios
-        for od in net.od:
+        for od in net.od_pairs:
             ratio_sum = 0
             for route in od.routes:
                 ratio_sum += route.target_ratio

--- a/jodeln/network/net_write.py
+++ b/jodeln/network/net_write.py
@@ -54,7 +54,7 @@ def export_node_sequences(net: 'Network', output_folder=None) -> None:
         Folder to export the node file, by default None indicates the current working
         directory as returned by os.getcwd().
     """
-    if net.od is None:
+    if net.od_pairs is None:
         print("Network does not contain any OD.")
         return
 
@@ -73,7 +73,7 @@ def export_node_sequences(net: 'Network', output_folder=None) -> None:
         turn_writer.writerow(["o_node", "d_node", "route", "a_node", "b_node", "c_node"])
         link_writer.writerow(["o_node", "d_node", "route", "a_node", "b_node"])
 
-        for od in net.od:
+        for od in net.od_pairs:
             o_name = net.node(od.origin).name
             d_name = net.node(od.destination).name
 
@@ -126,7 +126,7 @@ def export_route_list(net: 'Network', output_folder=None) -> None:
         directory as returned by os.getcwd().
     """
     
-    if net.od is None:
+    if net.od_pairs is None:
         print("Network does not contain any OD.")
         return
 
@@ -140,7 +140,7 @@ def export_route_list(net: 'Network', output_folder=None) -> None:
         
         list_writer = csv.writer(list_f)
 
-        for od in net.od:
+        for od in net.od_pairs:
             for route in od.routes:
                 list_writer.writerow([str(net.node(x).name) for x in route.nodes])
 

--- a/jodeln/network/netod.py
+++ b/jodeln/network/netod.py
@@ -14,16 +14,10 @@ class NetODpair():
         node ID of the OD origin.
     destination : int
         node ID of the OD destination.
-    seed_total_volume : float
-        Volume for this OD pair within the seed OD matrix.
-    est_total_volume : float
-        Volume for this OD pair within the estimated OD matrix.
-    routes : List[route]
-        List of all possible routes from origin to destination to include in the
-        OD optimization. One OD can contain multiple routes.
+    routes : list[NetRoute]
+        List of all possible routes from origin to destination. One OD can 
+        contain multiple routes.
     """
     origin: int
     destination: int
-    seed_total_volume: float
-    est_total_volume: float
     routes: list['NetRoute']

--- a/jodeln/od/od_read.py
+++ b/jodeln/od/od_read.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ..network.net import Network
 
-def od_from_csv(od_csv, net: 'Network'):
+def od_from_csv(od_csv, net: 'Network') -> dict[tuple[int, int], float]:
     """Creates an OD object from a csv OD matrix.
     
     csv is a square OD matrix (n rows = n columns), zones are ordered the same in the rows
@@ -55,7 +55,7 @@ def od_from_csv(od_csv, net: 'Network'):
     # i.e. zones in OD are found in Network
 
     # convert volume lists into a dictionary of {(o, d): volume}
-    od = {}
+    od: dict[tuple[int, int], float] = {}
     for o_name, volumes  in temp_od.items():
         o_node_key = net.get_node_by_name(o_name)[0]
         for i, v in enumerate(volumes):

--- a/jodeln/od/od_write.py
+++ b/jodeln/od/od_write.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from ..network.net import Network
 
 
-def export_od_as_list(net: 'Network', output_folder=None) -> None:
+def export_od_as_list(net: 'Network', od_mat: dict[tuple[int, int], float], output_folder=None) -> None:
     """Save the estimated OD to a csv file with one row per OD pair.
     
     csv columns are:
@@ -35,9 +35,13 @@ def export_od_as_list(net: 'Network', output_folder=None) -> None:
         directory as returned by os.getcwd().
     """
     
-    if net.od is None:
+    if net.od_pairs is None:
         print("Network does not contain any OD.")
         return
+
+    if od_mat is None:
+        print("OD Matrix is Empty.")
+        return       
 
     if output_folder is None:
         output_folder = os.getcwd()
@@ -50,11 +54,12 @@ def export_od_as_list(net: 'Network', output_folder=None) -> None:
         list_writer = csv.writer(list_f)
         list_writer.writerow(["o_node", "d_node", "volume"])
 
-        for od in net.od:
+        for od in net.od_pairs:
             o_name = net.node(od.origin).name
             d_name = net.node(od.destination).name
+            volume = od_mat[(od.origin, od.destination)]
 
-            list_writer.writerow([o_name, d_name, od.est_total_volume])
+            list_writer.writerow([o_name, d_name, volume])
 
 
 
@@ -89,7 +94,7 @@ def export_od_by_route(net: 'Network', output_folder=None) -> None:
         directory as returned by os.getcwd().
     """
     
-    if net.od is None:
+    if net.od_pairs is None:
         print("Network does not contain any OD.")
         return
 
@@ -104,7 +109,7 @@ def export_od_by_route(net: 'Network', output_folder=None) -> None:
         list_writer = csv.writer(list_f)
         list_writer.writerow(["o_node", "d_node", "route", "volume"])
 
-        for od in net.od:
+        for od in net.od_pairs:
             o_name = net.node(od.origin).name
             d_name = net.node(od.destination).name
             for route in od.routes:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -30,7 +30,10 @@ class TestModel(unittest.TestCase):
                    od_seed_file=os.path.join(net_path, "seed_matrix.csv"))
         
         res = model.estimate_od(1, 1, 1)
-        print('res (before abs): ', res)
+
+        print(f"\nestimated od: {model.od_estimated}\n")
+
+        print(f"\nres (before taking abs value): {res}\n")
         odme_res = [round(abs(x), 4) for x in res]
 
         expected_res = [0.5839, 0.9216, 0.5537, 1.1827]


### PR DESCRIPTION
Decoupling the OD matrices improves separation of concerns. This will allow future code to more easily import, export, and display multiple different OD matrices (seed matrix, matrices estimated via different methods, etc).

Changes also include:

- Adding an 'od_estimated' instance variable to the 'Model'.  This is consistent with the 'Model' already containing and 'od_seed' object.
- Removing OD volume info from the 'NetODPair' object and instead passing OD matrices from the 'Model' into various functions.
- Misc renaming, updating type hints, and cleaning.
