### PR TITLE
Show OD matrix in GUI

### DIFF
--- a/jodeln/gui/MarginTableModel.py
+++ b/jodeln/gui/MarginTableModel.py
@@ -1,0 +1,128 @@
+from abc import ABC, ABCMeta, abstractmethod
+from PySide2 import QtCore, QtGui
+from PySide2.QtCore import Qt
+
+# -------------------------
+# Resources:
+#   https://stackoverflow.com/questions/28799089/python-abc-multiple-inheritance
+#   https://stackoverflow.com/questions/57349105/python-abc-inheritance-with-specified-metaclass
+# -------------------------
+
+class QABCMeta(ABCMeta, type(QtCore.QAbstractTableModel)):
+    """Metaclass that combines ABC and QtCore.QAbstractTableModel"""
+    pass
+
+class MarginTableModel(ABC, metaclass=QABCMeta):
+    """Abstract base class to be multi-inherited together with QtCore.QAbstractTableModel"""
+    def __init__(self) -> None:
+        super().__init__()
+        self._data = None
+        self.n_rows = 0
+        self.n_cols = 0
+
+    @abstractmethod
+    def _set_n_rows_and_cols(self):
+        ...
+
+    @abstractmethod
+    def orientation_stat(self):
+        ...
+    
+    @abstractmethod
+    def orientation_zone(self):
+        ...
+        
+    @abstractmethod
+    def get_stat_coord(self, index):
+        ...
+
+    @abstractmethod
+    def get_zone_coord(self, index):
+        ...
+
+    def rowCount(self, index) -> int:
+        return self.n_rows
+    
+    def columnCount(self, index) -> int:
+        return self.n_cols
+    
+    def data(self, index, role):
+        if role == Qt.TextAlignmentRole:
+            return int(Qt.AlignRight | Qt.AlignVCenter)
+        
+        if role == Qt.DisplayRole:
+            stat_coord = self.get_stat_coord(index)
+            zone_coord = self.get_zone_coord(index)
+            
+            if stat_coord == 0:
+                return self._data['diff'][zone_coord]
+            if stat_coord == 1:
+                return self._data['targets'][zone_coord]
+            if stat_coord == 2:
+                return self._data['sums'][zone_coord]
+        
+        if (role == Qt.ForegroundRole) and (self.get_stat_coord(index) == 1):
+            return QtGui.QColor('purple')
+
+        if (role == Qt.ForegroundRole) and (self.get_stat_coord(index) == 2):
+            return QtGui.QColor('blue')
+    
+    def headerData(self, section: int, orientation: Qt.Orientation, role: int = ...):
+        if section == 0 and orientation == self.orientation_stat() and role == Qt.DisplayRole:
+            return "Δ"
+        if section == 1 and orientation == self.orientation_stat() and role == Qt.DisplayRole:
+            return "T"
+        if section == 2 and orientation == self.orientation_stat() and role == Qt.DisplayRole:
+            return "Σ"
+        
+        if orientation == self.orientation_zone() and role == Qt.DisplayRole:
+            return self._data['zone_names'][section]
+        
+        return super().headerData(section, orientation, role)
+
+    def load_data(self, data):
+        self._data = data      
+        self._set_n_rows_and_cols()
+
+
+
+class OriginMarginModel(MarginTableModel, QtCore.QAbstractTableModel):
+    def __init__(self) -> None:
+        super().__init__()    
+
+    def _set_n_rows_and_cols(self):
+        self.n_rows = len(self._data['sums'])
+        self.n_cols = 3
+
+    def orientation_stat(self):
+        return Qt.Horizontal
+    
+    def orientation_zone(self):
+        return Qt.Vertical
+        
+    def get_stat_coord(self, index):
+        return index.column()
+
+    def get_zone_coord(self, index):
+        return index.row()
+    
+
+class DestinationMarginModel(MarginTableModel, QtCore.QAbstractTableModel):
+    def __init__(self) -> None:
+        super().__init__()    
+
+    def _set_n_rows_and_cols(self):
+        self.n_rows = 3
+        self.n_cols = len(self._data['sums'])
+
+    def orientation_stat(self):
+        return Qt.Vertical
+    
+    def orientation_zone(self):
+        return Qt.Horizontal
+        
+    def get_stat_coord(self, index):
+        return index.row()
+
+    def get_zone_coord(self, index):
+        return index.column()

--- a/jodeln/gui/dialog_od_view.py
+++ b/jodeln/gui/dialog_od_view.py
@@ -1,0 +1,32 @@
+from PySide2.QtWidgets import QMainWindow
+from PySide2.QtCore import QSize
+
+from gui.ui_dialog_od_view import Ui_ODView
+
+
+class DialogODView(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.ui = Ui_ODView()
+        self.ui.setupUi(self)
+
+        self.ui.tabWidget.currentChanged.connect(self.tab_changed)
+        self.ui.actionFratar.triggered.connect(self.fratar_factor)
+
+    def load_od_data(self, od_seed, od_estimated, od_diff, origins, destinations, o_names, d_names):        
+        self.ui.mv1.load_od_data(od_seed, origins, destinations, o_names, d_names)
+        self.ui.mv2.load_od_data(od_estimated, origins, destinations, o_names, d_names)
+        self.ui.mv3.load_od_data(od_diff, origins, destinations, o_names, d_names)
+
+        
+    def tab_changed(self, index):
+        """Hack to force MatrixView widgets to show/hide their scrollbars as needed.
+        
+        Without this hack, MatrixView widgets will show their scrollbars if the
+        widgets are not on the initial tab shown by the dialog loads.
+        """
+        self.resize(QSize(self.size().width() + 1, self.size().height() + 1))
+        self.resize(QSize(self.size().width() - 1, self.size().height() - 1))
+
+    def fratar_factor(self):
+        print(f"Placeholder for Fratar Factor Estimation.")

--- a/jodeln/gui/dialog_od_view.ui
+++ b/jodeln/gui/dialog_od_view.ui
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ODView</class>
+ <widget class="QMainWindow" name="ODView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>819</width>
+    <height>528</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>OD Matrix</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QGridLayout" name="gridLayout_3">
+    <item row="0" column="0">
+     <widget class="QTabWidget" name="tabWidget">
+      <property name="tabPosition">
+       <enum>QTabWidget::North</enum>
+      </property>
+      <property name="tabShape">
+       <enum>QTabWidget::Rounded</enum>
+      </property>
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="tabSeed">
+       <attribute name="title">
+        <string>Seed Matrix</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="MatrixView" name="mv1" native="true"/>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tabEst">
+       <attribute name="title">
+        <string>Estimated Matrix</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="0">
+         <widget class="MatrixView" name="mv2" native="true"/>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tabDiff">
+       <attribute name="title">
+        <string>Diff Matrix</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout_4">
+        <item row="0" column="0">
+         <widget class="MatrixView" name="mv3" native="true"/>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+  <widget class="QMenuBar" name="menuBar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>819</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuODME">
+    <property name="title">
+     <string>Estimate OD</string>
+    </property>
+    <addaction name="actionFratar"/>
+   </widget>
+   <addaction name="menuODME"/>
+  </widget>
+  <action name="actionFratar">
+   <property name="text">
+    <string>Bi-proportional matrix factoring (Fratar Method)</string>
+   </property>
+  </action>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MatrixView</class>
+   <extends>QWidget</extends>
+   <header>gui.widget_matrixview</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/jodeln/gui/mainwindow.py
+++ b/jodeln/gui/mainwindow.py
@@ -12,6 +12,7 @@ from gui import schematic_scene, od_tablemodel
 from gui.dialog_open import DialogOpen
 from gui.dialog_export import DialogExport
 from gui.dialog_odme import DialogODME, CallbackOdmeParameters
+from gui.dialog_od_view import DialogODView
 
 from typing import TYPE_CHECKING
 
@@ -42,13 +43,18 @@ class MainWindow(QMainWindow):
         # Dialog ODME
         self.dialog_odme = DialogODME(cb_odme=self.estimate_od)
 
+        # Dialog OD View
+        self.dialog_od_view = DialogODView()
+
         # Connect push buttons to slot functions
         self.ui.pbShowDialogOpen.clicked.connect(self.show_dialog_open)
         self.ui.pbShowExportDialog.clicked.connect(self.show_dialog_export)
         self.ui.pbShowODEstimation.clicked.connect(self.show_dialog_odme)
+        self.ui.pbODView.clicked.connect(self.show_dialog_od_view)
 
         # Disable buttons that should only be used after loading a network
         self.ui.pbShowExportDialog.setEnabled(False)
+        self.ui.pbODView.setEnabled(False)
         self.ui.pbShowODEstimation.setEnabled(False)
 
         # Setup graphics view
@@ -76,6 +82,28 @@ class MainWindow(QMainWindow):
 
     def show_dialog_odme(self) -> None:
         self.dialog_odme.show()
+
+    def show_dialog_od_view(self) -> None:
+        self.dialog_od_view.show()
+
+        origins = set([o for (o, _) in self.model.od_seed.keys()])
+        destinations = set([d for (_, d) in self.model.od_seed.keys()])
+
+        origins = list(origins)
+        destinations = list(destinations)
+
+        o_names = [self.model.get_node_name(o) for o in origins]
+        d_names = [self.model.get_node_name(d) for d in origins]
+
+        self.dialog_od_view.load_od_data(
+            self.model.od_seed,
+            self.model.od_estimated,
+            self.model.od_diff,
+            origins,
+            destinations,
+            o_names,
+            d_names
+        )
 
 
     def load(self) -> None:
@@ -123,6 +151,7 @@ class MainWindow(QMainWindow):
         self.schematic_scene.load_routes(routes)
 
         self.ui.pbShowExportDialog.setEnabled(True)
+        self.ui.pbODView.setEnabled(True)
         self.ui.pbShowODEstimation.setEnabled(True)
 
     def estimate_od(self, parms: CallbackOdmeParameters) -> None:

--- a/jodeln/gui/mainwindow.ui
+++ b/jodeln/gui/mainwindow.ui
@@ -53,6 +53,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QPushButton" name="pbODView">
+        <property name="text">
+         <string>View OD</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QPushButton" name="pbShowODEstimation">
         <property name="text">
          <string>OD Estimation</string>

--- a/jodeln/gui/ui_dialog_od_view.py
+++ b/jodeln/gui/ui_dialog_od_view.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'dialog_od_view.ui'
+##
+## Created by: Qt User Interface Compiler version 5.15.2
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide2.QtCore import *
+from PySide2.QtGui import *
+from PySide2.QtWidgets import *
+
+from gui.widget_matrixview import MatrixView
+
+
+class Ui_ODView(object):
+    def setupUi(self, ODView):
+        if not ODView.objectName():
+            ODView.setObjectName(u"ODView")
+        ODView.resize(819, 528)
+        self.actionFratar = QAction(ODView)
+        self.actionFratar.setObjectName(u"actionFratar")
+        self.centralwidget = QWidget(ODView)
+        self.centralwidget.setObjectName(u"centralwidget")
+        self.gridLayout_3 = QGridLayout(self.centralwidget)
+        self.gridLayout_3.setObjectName(u"gridLayout_3")
+        self.tabWidget = QTabWidget(self.centralwidget)
+        self.tabWidget.setObjectName(u"tabWidget")
+        self.tabWidget.setTabPosition(QTabWidget.North)
+        self.tabWidget.setTabShape(QTabWidget.Rounded)
+        self.tabSeed = QWidget()
+        self.tabSeed.setObjectName(u"tabSeed")
+        self.gridLayout = QGridLayout(self.tabSeed)
+        self.gridLayout.setObjectName(u"gridLayout")
+        self.mv1 = MatrixView(self.tabSeed)
+        self.mv1.setObjectName(u"mv1")
+
+        self.gridLayout.addWidget(self.mv1, 0, 0, 1, 1)
+
+        self.tabWidget.addTab(self.tabSeed, "")
+        self.tabEst = QWidget()
+        self.tabEst.setObjectName(u"tabEst")
+        self.gridLayout_2 = QGridLayout(self.tabEst)
+        self.gridLayout_2.setObjectName(u"gridLayout_2")
+        self.mv2 = MatrixView(self.tabEst)
+        self.mv2.setObjectName(u"mv2")
+
+        self.gridLayout_2.addWidget(self.mv2, 0, 0, 1, 1)
+
+        self.tabWidget.addTab(self.tabEst, "")
+        self.tabDiff = QWidget()
+        self.tabDiff.setObjectName(u"tabDiff")
+        self.gridLayout_4 = QGridLayout(self.tabDiff)
+        self.gridLayout_4.setObjectName(u"gridLayout_4")
+        self.mv3 = MatrixView(self.tabDiff)
+        self.mv3.setObjectName(u"mv3")
+
+        self.gridLayout_4.addWidget(self.mv3, 0, 0, 1, 1)
+
+        self.tabWidget.addTab(self.tabDiff, "")
+
+        self.gridLayout_3.addWidget(self.tabWidget, 0, 0, 1, 1)
+
+        ODView.setCentralWidget(self.centralwidget)
+        self.statusbar = QStatusBar(ODView)
+        self.statusbar.setObjectName(u"statusbar")
+        ODView.setStatusBar(self.statusbar)
+        self.menuBar = QMenuBar(ODView)
+        self.menuBar.setObjectName(u"menuBar")
+        self.menuBar.setGeometry(QRect(0, 0, 819, 21))
+        self.menuODME = QMenu(self.menuBar)
+        self.menuODME.setObjectName(u"menuODME")
+        ODView.setMenuBar(self.menuBar)
+
+        self.menuBar.addAction(self.menuODME.menuAction())
+        self.menuODME.addAction(self.actionFratar)
+
+        self.retranslateUi(ODView)
+
+        self.tabWidget.setCurrentIndex(0)
+
+
+        QMetaObject.connectSlotsByName(ODView)
+    # setupUi
+
+    def retranslateUi(self, ODView):
+        ODView.setWindowTitle(QCoreApplication.translate("ODView", u"OD Matrix", None))
+        self.actionFratar.setText(QCoreApplication.translate("ODView", u"Bi-proportional matrix factoring (Fratar Method)", None))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabSeed), QCoreApplication.translate("ODView", u"Seed Matrix", None))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabEst), QCoreApplication.translate("ODView", u"Estimated Matrix", None))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabDiff), QCoreApplication.translate("ODView", u"Diff Matrix", None))
+        self.menuODME.setTitle(QCoreApplication.translate("ODView", u"Estimate OD", None))
+    # retranslateUi
+

--- a/jodeln/gui/ui_mainwindow.py
+++ b/jodeln/gui/ui_mainwindow.py
@@ -46,6 +46,11 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout.addWidget(self.pbShowExportDialog)
 
+        self.pbODView = QPushButton(self.centralwidget)
+        self.pbODView.setObjectName(u"pbODView")
+
+        self.horizontalLayout.addWidget(self.pbODView)
+
         self.pbShowODEstimation = QPushButton(self.centralwidget)
         self.pbShowODEstimation.setObjectName(u"pbShowODEstimation")
 
@@ -162,6 +167,7 @@ class Ui_MainWindow(object):
         MainWindow.setWindowTitle(QCoreApplication.translate("MainWindow", u"Jodeln", None))
         self.pbShowDialogOpen.setText(QCoreApplication.translate("MainWindow", u"Open", None))
         self.pbShowExportDialog.setText(QCoreApplication.translate("MainWindow", u"Export", None))
+        self.pbODView.setText(QCoreApplication.translate("MainWindow", u"View OD", None))
         self.pbShowODEstimation.setText(QCoreApplication.translate("MainWindow", u"OD Estimation", None))
         self.filterToggle.setText(QCoreApplication.translate("MainWindow", u"Filter", None))
         self.label.setText(QCoreApplication.translate("MainWindow", u"Origin", None))

--- a/jodeln/gui/ui_widget_matrixview.py
+++ b/jodeln/gui/ui_widget_matrixview.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'widget_matrixview.ui'
+##
+## Created by: Qt User Interface Compiler version 5.15.2
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide2.QtCore import *
+from PySide2.QtGui import *
+from PySide2.QtWidgets import *
+
+
+class Ui_MatrixView(object):
+    def setupUi(self, MatrixView):
+        if not MatrixView.objectName():
+            MatrixView.setObjectName(u"MatrixView")
+        MatrixView.resize(632, 472)
+        self.gridLayout = QGridLayout(MatrixView)
+        self.gridLayout.setObjectName(u"gridLayout")
+        self.tvMarginD = QTableView(MatrixView)
+        self.tvMarginD.setObjectName(u"tvMarginD")
+        sizePolicy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.tvMarginD.sizePolicy().hasHeightForWidth())
+        self.tvMarginD.setSizePolicy(sizePolicy)
+        self.tvMarginD.setMaximumSize(QSize(16777215, 120))
+        self.tvMarginD.setFrameShape(QFrame.StyledPanel)
+        self.tvMarginD.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.tvMarginD.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
+        self.gridLayout.addWidget(self.tvMarginD, 0, 1, 1, 1)
+
+        self.tvMarginO = QTableView(MatrixView)
+        self.tvMarginO.setObjectName(u"tvMarginO")
+        sizePolicy1 = QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
+        sizePolicy1.setHorizontalStretch(0)
+        sizePolicy1.setVerticalStretch(0)
+        sizePolicy1.setHeightForWidth(self.tvMarginO.sizePolicy().hasHeightForWidth())
+        self.tvMarginO.setSizePolicy(sizePolicy1)
+        self.tvMarginO.setMaximumSize(QSize(160, 16777215))
+        self.tvMarginO.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.tvMarginO.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
+        self.gridLayout.addWidget(self.tvMarginO, 1, 0, 1, 1)
+
+        self.tvMatrix = QTableView(MatrixView)
+        self.tvMatrix.setObjectName(u"tvMatrix")
+        self.tvMatrix.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.tvMatrix.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
+        self.gridLayout.addWidget(self.tvMatrix, 1, 1, 1, 1)
+
+        self.vsbar = QScrollBar(MatrixView)
+        self.vsbar.setObjectName(u"vsbar")
+        self.vsbar.setOrientation(Qt.Vertical)
+
+        self.gridLayout.addWidget(self.vsbar, 1, 2, 1, 1)
+
+        self.hsbar = QScrollBar(MatrixView)
+        self.hsbar.setObjectName(u"hsbar")
+        self.hsbar.setOrientation(Qt.Horizontal)
+
+        self.gridLayout.addWidget(self.hsbar, 2, 1, 1, 1)
+
+
+        self.retranslateUi(MatrixView)
+
+        QMetaObject.connectSlotsByName(MatrixView)
+    # setupUi
+
+    def retranslateUi(self, MatrixView):
+        MatrixView.setWindowTitle(QCoreApplication.translate("MatrixView", u"MatrixView", None))
+    # retranslateUi
+

--- a/jodeln/gui/widget_matrixview.py
+++ b/jodeln/gui/widget_matrixview.py
@@ -1,0 +1,172 @@
+from PySide2 import QtCore, QtGui, QtWidgets
+from PySide2.QtCore import Qt
+
+from gui.ui_widget_matrixview import Ui_MatrixView
+from gui.MarginTableModel import OriginMarginModel, DestinationMarginModel
+
+class TableModel(QtCore.QAbstractTableModel):
+    def __init__(self):
+        super().__init__()
+        self._data = None
+        self.n_rows = 0
+        self.n_cols = 0
+        self.origins = None
+        self.destinations = None
+
+    def data(self, index, role):
+        if role == Qt.TextAlignmentRole:
+            return int(Qt.AlignRight | Qt.AlignVCenter)
+        
+        if role == Qt.DisplayRole:
+            o = self.origins[index.row()]
+            d = self.destinations[index.column()]
+            return self._data[(o, d)]
+        
+        if role == Qt.ForegroundRole:
+            o = self.origins[index.row()]
+            d = self.destinations[index.column()]
+            if self._data[(o, d)] == 0:
+                return QtGui.QColor('grey')
+        
+        if role == Qt.BackgroundRole:
+            if index.row() == index.column():
+                return QtGui.QColor('lightGrey')
+
+
+    def headerData(self, section: int, orientation: Qt.Orientation, role: int):
+        if orientation == Qt.Vertical and role == Qt.DisplayRole:
+            return self.o_names[section]
+        
+        if orientation == Qt.Horizontal and role == Qt.DisplayRole:
+            return self.d_names[section]
+        
+        return super().headerData(section, orientation, role)
+
+    def rowCount(self, index):
+        return self.n_rows
+
+    def columnCount(self, index):
+        return self.n_cols
+    
+    def load_data(self, od_mat, origins, destinations, o_names, d_names):
+        self._data = od_mat
+        
+        self.origins = origins
+        self.destinations = destinations
+
+        self.o_names = o_names
+        self.d_names = d_names
+
+        self.n_rows = len(self.origins)
+        self.n_cols = len(self.destinations)
+    
+
+class MatrixView(QtWidgets.QWidget):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.ui = Ui_MatrixView()
+        self.ui.setupUi(self)
+
+        self.od_table = TableModel()
+        self.row_margins = OriginMarginModel()
+        self.col_margins = DestinationMarginModel()
+
+        # Synchronize vertical scrolling
+        self.ui.tvMatrix.verticalScrollBar().valueChanged.connect(self.scroll_vertical)
+        self.ui.tvMarginO.verticalScrollBar().valueChanged.connect(self.scroll_vertical)        
+        self.ui.vsbar.valueChanged.connect(self.scroll_vertical)
+
+        # Synchronize horizontal scrolling
+        self.ui.tvMatrix.horizontalScrollBar().valueChanged.connect(self.scroll_horizontal)
+        self.ui.tvMarginD.horizontalScrollBar().valueChanged.connect(self.scroll_horizontal)        
+        self.ui.hsbar.valueChanged.connect(self.scroll_horizontal)
+
+    def scroll_vertical(self, value):
+        self.ui.tvMarginO.verticalScrollBar().setValue(value)
+        self.ui.tvMatrix.verticalScrollBar().setValue(value)
+        self.ui.vsbar.setValue(value)
+
+    def scroll_horizontal(self, value):
+        self.ui.tvMarginD.horizontalScrollBar().setValue(value)
+        self.ui.tvMatrix.horizontalScrollBar().setValue(value)
+        self.ui.hsbar.setValue(value)
+
+    def set_header_size(self):
+
+        def set_fixed_resize_mode(table_view):
+            """Helper Function for setting the resize mode on a table view."""
+            table_view.verticalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
+            table_view.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Fixed)
+
+        set_fixed_resize_mode(self.ui.tvMatrix)
+        set_fixed_resize_mode(self.ui.tvMarginO)
+        set_fixed_resize_mode(self.ui.tvMarginD)
+
+        for i in range(0, 3):
+            self.ui.tvMarginO.setColumnWidth(i, 40)
+
+        for i in range(0, self.od_table.n_cols):
+            self.ui.tvMatrix.setColumnWidth(i, 40)
+            self.ui.tvMarginD.setColumnWidth(i, 40)
+
+        self.ui.tvMarginD.verticalHeader().setFixedWidth(self.ui.tvMatrix.verticalHeader().size().width())
+
+    def load_od_data(self, od_mat, origins, destinations, o_names, d_names):
+        
+        self.od_table.load_data(od_mat, origins, destinations, o_names, d_names)
+        self.ui.tvMatrix.setModel(self.od_table)
+
+        o_sums, d_sums = margin_sums(od_mat, origins, destinations)
+        o_sums = [v for _, v in o_sums.items()]
+        d_sums = [v for _, v in d_sums.items()]
+
+        o_targets = [10 * v for v in o_sums]
+        d_targets = [10 * v for v in d_sums]
+
+        o_diffs = [s - t for s, t in zip(o_sums, o_targets)]
+        d_diffs = [s - t for s, t in zip(d_sums, d_targets)]
+
+        row_margin = {
+            'zone_names': o_names,
+            'sums': o_sums,
+            'targets': o_targets,
+            'diff': o_diffs,
+        }
+
+        self.row_margins.load_data(row_margin)
+        self.ui.tvMarginO.setModel(self.row_margins)
+
+        col_margin = {
+            'zone_names': d_names,
+            'sums': d_sums,
+            'targets': d_targets,
+            'diff': d_diffs,
+        }
+
+        self.col_margins.load_data(col_margin)
+        self.ui.tvMarginD.setModel(self.col_margins)
+
+        # Update GUI now that data is shown in the OD table. 
+        self.set_header_size()
+
+        
+    def resizeEvent(self, event) -> None:
+        self.ui.vsbar.setMinimum(self.ui.tvMatrix.verticalScrollBar().minimum())
+        self.ui.hsbar.setMinimum(self.ui.tvMatrix.horizontalScrollBar().minimum())
+        
+        self.ui.vsbar.setMaximum(self.ui.tvMatrix.verticalScrollBar().maximum())
+        self.ui.hsbar.setMaximum(self.ui.tvMatrix.horizontalScrollBar().maximum())
+
+        return super().resizeEvent(event)
+
+def margin_sums(od_mat, origins, destinations):
+    pass
+    origin_sums = dict.fromkeys(origins, 0)
+    destination_sums = dict.fromkeys(destinations, 0)
+
+    for (o, d), v in od_mat.items():
+        origin_sums[o] += v
+        destination_sums[d] += v
+
+    return (origin_sums, destination_sums)
+    

--- a/jodeln/gui/widget_matrixview.ui
+++ b/jodeln/gui/widget_matrixview.ui
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MatrixView</class>
+ <widget class="QWidget" name="MatrixView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>632</width>
+    <height>472</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MatrixView</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="1">
+    <widget class="QTableView" name="tvMarginD">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>120</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QTableView" name="tvMarginO">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>160</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QTableView" name="tvMatrix">
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QScrollBar" name="vsbar">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QScrollBar" name="hsbar">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/tests/test_od_view.py
+++ b/tests/test_od_view.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import unittest
+from PySide2.QtWidgets import QApplication
+from PySide2.QtTest import QTest
+from PySide2.QtCore import Qt, QEventLoop, QTimer
+from PySide2.QtWidgets import QDialogButtonBox
+
+from context import jodeln
+import jodeln.main
+from jodeln.model import Model
+
+
+def event_loop(msec):
+    """Event loop to show the GUI during a unit test. 
+    
+    https://www.qtcentre.org/threads/23541-Displaying-GUI-events-with-QtTest
+    """
+    loop = QEventLoop()
+    timer = QTimer()
+    timer.timeout.connect(loop.quit)
+    timer.setSingleShot(True)
+    timer.start(msec)
+    loop.exec_()
+
+class MainTest(unittest.TestCase):
+    def setUp(self) -> None:
+        model = Model()
+        self.window = jodeln.main.MainWindow(model)
+        return super().setUp()
+
+    def test_draw(self):
+        net_folder = os.path.join(os.getcwd(), "tests", "networks", "net01")
+        self.window.show()
+        QTest.mouseClick(self.window.ui.pbShowDialogOpen, Qt.LeftButton)
+        self.window.dialog_open.ui.leLinks.setText(os.path.join(net_folder, "links.csv"))
+        self.window.dialog_open.ui.leNodes.setText(os.path.join(net_folder, "nodes.csv"))
+        self.window.dialog_open.ui.leSeedOD.setText(os.path.join(net_folder, "seed_matrix.csv"))
+        QTest.mouseClick(self.window.dialog_open.ui.buttonBox.button(QDialogButtonBox.Ok), Qt.LeftButton)
+        event_loop(999999)
+        self.assertEqual(1, 1)
+
+
+if __name__ == '__main__':
+    app = QApplication(sys.argv)
+    unittest.main()


### PR DESCRIPTION
Code in this pull request does the following:

- Shows the seed, estimated, and difference OD matrices in the GUI.
- Sets up placeholders for future implementation and/or refactoring of OD estimation methods.

Additional work is needed to load target volumes for zone origin and destination totals. There is placeholder code in `widget_matrixview.py` that sets the zone targets to equal 10x the origin/destination sums.
