### PR TITLE
Implement Fratar Factor OD Estimation

### DIFF
--- a/jodeln/gui/dialog_od_view.py
+++ b/jodeln/gui/dialog_od_view.py
@@ -1,22 +1,42 @@
+from copy import deepcopy
+
 from PySide2.QtWidgets import QMainWindow
 from PySide2.QtCore import QSize
 
 from gui.ui_dialog_od_view import Ui_ODView
+from od.od_matrix import ODMatrix
+
+from typing import Protocol
+
+class Model(Protocol):
+    def estimate_od_fratar(self):
+        ...
+    @property
+    def od_seed(self) -> ODMatrix:
+        ...
+    @property
+    def od_estimated(self) -> ODMatrix:
+        ...
+    @property
+    def od_diff(self) -> ODMatrix:
+        ...
 
 
 class DialogODView(QMainWindow):
-    def __init__(self):
+    def __init__(self, model: Model):
         super().__init__()
         self.ui = Ui_ODView()
         self.ui.setupUi(self)
 
+        self.model = model
+
         self.ui.tabWidget.currentChanged.connect(self.tab_changed)
         self.ui.actionFratar.triggered.connect(self.fratar_factor)
 
-    def load_od_data(self, od_seed, od_estimated, od_diff):
-        self.ui.mv1.load_od_data(od_seed)
-        self.ui.mv2.load_od_data(od_estimated)
-        self.ui.mv3.load_od_data(od_diff)
+    def load_od_data(self):
+        self.ui.mv1.load_od_data(self.model.od_seed)
+        self.ui.mv2.load_od_data(self.model.od_estimated)
+        self.ui.mv3.load_od_data(self.model.od_diff)
 
         
     def tab_changed(self, index):
@@ -29,4 +49,6 @@ class DialogODView(QMainWindow):
         self.resize(QSize(self.size().width() - 1, self.size().height() - 1))
 
     def fratar_factor(self):
-        print(f"Placeholder for Fratar Factor Estimation.")
+        self.model.estimate_od_fratar()
+        self.ui.mv2.load_od_data(self.model.od_estimated)
+        self.ui.mv3.load_od_data(self.model.od_diff)

--- a/jodeln/gui/mainwindow.py
+++ b/jodeln/gui/mainwindow.py
@@ -44,7 +44,7 @@ class MainWindow(QMainWindow):
         self.dialog_odme = DialogODME(cb_odme=self.estimate_od)
 
         # Dialog OD View
-        self.dialog_od_view = DialogODView()
+        self.dialog_od_view = DialogODView(self.model)
 
         # Connect push buttons to slot functions
         self.ui.pbShowDialogOpen.clicked.connect(self.show_dialog_open)
@@ -85,12 +85,7 @@ class MainWindow(QMainWindow):
 
     def show_dialog_od_view(self) -> None:
         self.dialog_od_view.show()
-
-        self.dialog_od_view.load_od_data(
-            self.model.od_seed,
-            self.model.od_estimated,
-            self.model.od_diff
-        )
+        self.dialog_od_view.load_od_data()
 
 
     def load(self) -> None:

--- a/jodeln/gui/widget_matrixview.py
+++ b/jodeln/gui/widget_matrixview.py
@@ -121,15 +121,13 @@ class MatrixView(QtWidgets.QWidget):
         self.od_table.load_data(od_mat)
         self.ui.tvMatrix.setModel(self.od_table)
 
-        # Temporary Targets. TODO: get real targets from user input.
-        targets_o = [10 * v for _, v in od_mat.sums_o.items()]
-        targets_d = [10 * v for _, v in od_mat.sums_d.items()]
+        targets_o = [v for _, v in od_mat.targets_o.items()]
+        targets_d = [v for _, v in od_mat.targets_d.items()]
 
         diffs_o = []
         diffs_d = []
 
-        # Compute diff between margin sums and temporary targets. 
-        # TODO: compute diff using real targets from user input.
+        # Compute diff between margin sums and targets. 
         for i, (k, s) in enumerate(od_mat.sums_o.items()):
             diffs_o.append(s - targets_o[i])
 
@@ -158,6 +156,9 @@ class MatrixView(QtWidgets.QWidget):
 
         # Update GUI now that data is shown in the OD table. 
         self.set_header_size()
+        self.od_table.layoutChanged.emit()
+        self.row_margins.layoutChanged.emit()
+        self.col_margins.layoutChanged.emit()
 
         
     def resizeEvent(self, event) -> None:

--- a/jodeln/od/od_fratar.py
+++ b/jodeln/od/od_fratar.py
@@ -1,0 +1,73 @@
+"""Biproportional Matrix Factoring (Fratar Factoring)"""
+from copy import deepcopy
+from enum import Enum
+
+from od.od_matrix import ODMatrix, create_od_from_source
+
+class ODAxis(Enum):
+    """Axis in an ODMatrix. 
+    
+    Values are used to get the corresponding zone from an (O, D) dictionary key.
+    For example: 
+        ODMatrix.volume = {(8, 9) = 32.7}
+        key = (8, 9)
+        key[ODAxis.ORIGIN] = 8
+        key[ODAxis.DESTINATION] = 9
+    """
+    ORIGIN = 0
+    DESTINATION = 1
+
+def fratar(od_seed: ODMatrix) -> ODMatrix:
+
+    # Limit number of Fratar factoring iterations
+    MAX_ITERATIONS = 10
+
+    od_1 = create_od_from_source(od_seed, copy_volume=True, copy_targets=True)
+    od_2 = create_od_from_source(od_seed, copy_volume=True, copy_targets=True)
+
+    def fratar_iter(od: ODMatrix, axis: ODAxis):
+        """Helper function to do row/col iterations.
+        Row Iter: axis = ODAxis.ORIGIN = 0 
+        Col Iter: axis = ODAxis.DESTINATION = 1
+        """
+        if axis is ODAxis.ORIGIN:
+            targets = od.targets_o
+            margin_sums = od.sums_o
+        elif axis is ODAxis.DESTINATION:
+            targets = od.targets_d
+            margin_sums = od.sums_d
+        else:
+            raise Exception(f"Axis {axis} unknown Expected ODAxis.ORIGIN or ODAxis.DESTINATION.")
+
+        for k, v in od.volume.items():
+            zone = k[axis.value]
+            if targets[zone] == -1:
+                continue
+            elif margin_sums[zone] == 0:
+                od.volume[k] = 0
+            else:    
+                od.volume[k] = v * targets[zone] / margin_sums[zone]
+        
+        od.set_margin_sums()
+
+
+    for _ in range(0, MAX_ITERATIONS):
+        # Swap matrices to save results for both row & col iterations
+        od_1, od_2 = od_2, od_1
+
+        # Row Iteration
+        fratar_iter(od_1, ODAxis.ORIGIN)
+
+        # Col Iteration
+        fratar_iter(od_2, ODAxis.DESTINATION)
+
+    # Average last iterations
+    od_3 = create_od_from_source(od_seed, copy_targets=True)
+
+    for k in od_3.volume:
+        od_3.volume[k] = (od_1.volume[k] + od_2.volume[k]) / 2.0
+
+    od_3.set_margin_sums()
+
+    return od_3
+    

--- a/jodeln/od/od_matrix.py
+++ b/jodeln/od/od_matrix.py
@@ -51,17 +51,33 @@ class ODMatrix:
             self.sums_o[o] += v
             self.sums_d[d] += v
 
-def create_od_from_source(source_od: ODMatrix) -> ODMatrix:
-    """Create an OD matrix, filled with zero volume, based on the input source matrix."""
+def create_od_from_source(
+        source_od: ODMatrix,
+        copy_volume: bool = False,
+        copy_targets: bool = False
+        ) -> ODMatrix:
+    """Create an OD matrix based on the input source matrix.
+    
+    If the copy parameters are False, then the new OD matrix is filled with zeros.
+    """
+    if copy_volume:
+        new_volume = deepcopy(source_od.volume)
+    else:
+        new_volume = dict.fromkeys(source_od.volume, 0)
+
+    if copy_targets:
+        new_targets_o = deepcopy(source_od.targets_o)
+        new_targets_d = deepcopy(source_od.targets_d)
+    else:
+        new_targets_o = dict.fromkeys(source_od.targets_o, 0)
+        new_targets_d = dict.fromkeys(source_od.targets_d, 0)
+
     return ODMatrix(
-        volume=dict.fromkeys(source_od.volume, 0),
+        volume=new_volume,
         origins=deepcopy(source_od.origins),
         destinations=deepcopy(source_od.destinations),
         names_o=deepcopy(source_od.names_o),
         names_d=deepcopy(source_od.names_d),
-        targets_o=dict.fromkeys(source_od.targets_o, 0),
-        targets_d=dict.fromkeys(source_od.targets_d, 0)
-    )
-
-
-    
+        targets_o=new_targets_o,
+        targets_d=new_targets_d
+    )  

--- a/tests/test_fratar.py
+++ b/tests/test_fratar.py
@@ -1,0 +1,48 @@
+"""
+Test suite for Model.py
+"""
+
+import unittest
+
+from context import jodeln
+from jodeln.od import od_fratar
+from jodeln.od.od_matrix import ODMatrix
+
+volumes = {
+    (0, 0): 5,
+    (0, 1): 10,
+    (1, 0): 3,
+    (1, 1): 33
+}
+
+sample_od = ODMatrix(
+    volume=volumes,
+    origins=[0, 1],
+    destinations=[0, 1],
+    names_o=['0', '1'],
+    names_d=['0', '1'],
+    targets_o={0: 20, 1: 30},
+    targets_d={0: 17, 1: 51}
+)
+
+
+class TestFratar(unittest.TestCase):
+
+    # def test_margin_sums(self):
+    #     """Test summing origin and destination totals."""
+    #     origin_sums, destinations_sums = od_fratar.get_default_margin_sums(sample_od)
+    #     od_fratar.margin_sums(sample_od, origin_sums, destinations_sums)
+
+    #     self.assertEqual((origin_sums, destinations_sums), 
+    #                      ({0: 15, 1: 36}, {0: 8, 1: 43}))
+
+
+    def test_fratar(self):
+        res = od_fratar.fratar(sample_od)
+        print(res.volume)
+        print(res.sums_o)
+        print(res.sums_d)
+        self.assertEqual(1, 1)       
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements the Fratar Factoring algorithm (aka Biproportional Matrix Factoring).

Still TODO:

- Need to get origin/destination targets from the user. The code currently uses placeholder targets.
- The margin stats on the difference matrix (`model.od_diff`) do not make sense and are not intuitive (sum, target, delta). Should these margin stats be removed?