### PR TITLE
Refactor MVC implementation

### DIFF
--- a/jodeln/gui/dialog_export.py
+++ b/jodeln/gui/dialog_export.py
@@ -2,22 +2,30 @@ from PySide2.QtWidgets import QWidget, QFileDialog
 
 from gui.ui_dialog_export import Ui_Dialog
 
+from typing import Protocol
+
+class Model(Protocol):
+    def export_turns(self, output_folder):
+        ...
+    def export_node_sequence(self, output_folder):
+        ...
+    def export_route_list(self, output_folder):
+        ...
 
 
 class DialogExport(QWidget):
     """Dialog for exporting list of turns, paths, etc."""
-    def __init__(self, 
-                 cb_export_links_and_turns_by_od, 
-                 cb_export_routes,
-                 cb_export_turns):
+    def __init__(self, model: Model):
 
         super().__init__()
         self.ui = Ui_Dialog()
         self.ui.setupUi(self)
         
-        self.ui.pbExportLinksAndTurnsByOD.clicked.connect(lambda: cb_export_links_and_turns_by_od(self.ui.leExportFolder.text()))
-        self.ui.pbExportRoutes.clicked.connect(lambda: cb_export_routes(self.ui.leExportFolder.text()))
-        self.ui.pbExportTurns.clicked.connect(lambda: cb_export_turns(self.ui.leExportFolder.text()))
+        self.model = model
+
+        self.ui.pbExportLinksAndTurnsByOD.clicked.connect(self.export_node_sequence)
+        self.ui.pbExportRoutes.clicked.connect(self.export_routes)
+        self.ui.pbExportTurns.clicked.connect(self.export_turns)
 
         self.ui.pbExportFolder.clicked.connect(self.on_pbExportFolder_click)
 
@@ -33,3 +41,13 @@ class DialogExport(QWidget):
             options=QFileDialog.ShowDirsOnly | QFileDialog.DontResolveSymlinks)
 
         self.ui.leExportFolder.setText(export_folder)
+
+    def export_turns(self):
+        self.model.export_turns(self.ui.leExportFolder.text())
+
+    def export_node_sequence(self):
+        self.model.export_node_sequence(self.ui.leExportFolder.text())
+    
+    def export_routes(self):
+        self.model.export_route_list(self.ui.leExportFolder.text())
+        

--- a/jodeln/gui/dialog_odme.py
+++ b/jodeln/gui/dialog_odme.py
@@ -3,26 +3,26 @@ from PySide2.QtGui import QDoubleValidator
 
 from gui.ui_dialog_odme import Ui_Dialog
 
-from typing import Callable
-from dataclasses import dataclass
+from typing import Protocol
 
-@dataclass(slots=True)
-class CallbackOdmeParameters():
-    """Group parameters needed for the ODME Callback Function."""
-    weight_GEH: float
-    weight_odsse: float
-    weight_route_ratio: float
-    export_path: str
+class Model(Protocol):
+    def estimate_od(self, weight_total_geh=None, weight_odsse=None, weight_route_ratio=None):
+        ...
+    def export_od(self, output_folder=None) -> None:
+        ...
+    def export_od_by_route(self, output_folder=None) -> None:
+        ...
+
 
 class DialogODME(QWidget):
     """Dialog for doing OD Estimation."""
-    def __init__(self, cb_odme: Callable[[CallbackOdmeParameters], None]):
+    def __init__(self, model: Model):
 
         super().__init__()
         self.ui = Ui_Dialog()
         self.ui.setupUi(self)
 
-        self.cb_odme = cb_odme
+        self.model = model
 
         self.ui.pbEstimateOD.clicked.connect(self.estimate_od)
     
@@ -47,14 +47,14 @@ class DialogODME(QWidget):
 
     def estimate_od(self) -> None:
         """Run OD matrix estimation."""
-
-        self.cb_odme(
-            CallbackOdmeParameters(
-                weight_GEH=float(self.ui.leWeightGEH.text()),
+        self.model.estimate_od(
+                weight_total_geh=float(self.ui.leWeightGEH.text()),
                 weight_odsse=float(self.ui.leWeightODSSE.text()),
-                weight_route_ratio=float(self.ui.leWeightRouteRatio.text()),
-                export_path=self.ui.leExportFolder.text())
+                weight_route_ratio=float(self.ui.leWeightRouteRatio.text())
             )
+        
+        self.model.export_od(self.ui.leExportFolder.text())
+        self.model.export_od_by_route(self.ui.leExportFolder.text())
 
     def on_pbExportFolder_click(self) -> None:
         """Open a standard file dialog for selecting the export folder."""

--- a/jodeln/model.py
+++ b/jodeln/model.py
@@ -53,7 +53,7 @@ class Model():
         #: ODMatrix: Difference matrix = od_estimated - od_seed
         self.od_diff: ODMatrix = None
 
-    def load(self, node_file=None, links_file=None, od_seed_file=None, turns_file=None, od_routes_file=None) -> None:
+    def load(self, node_file=None, links_file=None, od_seed_file=None, turns_file=None, od_routes_file=None) -> bool:
         """Populate network and od variables with user supplied data.
 
         Parameters


### PR DESCRIPTION
This pull request uses `Protocol` from the `typing` module to create better consistency in Jodeln's model-view-controller (MVC) implementation. 

Previous code used a mix of callbacks, dependency injection, and Protocols. Updated code is more consistent by connecting the `model` to views via Protocol. The resulting code is also has better separation of concerns in the GUI python files (less code in the `mainwindow.py` and more code shifted to the `dialog_*.py` views.