### PR TITLE
Consolidate GUI for viewing and estimating OD

### DIFF
--- a/jodeln/gui/dialog_od_view.py
+++ b/jodeln/gui/dialog_od_view.py
@@ -4,9 +4,11 @@ from PySide2.QtWidgets import QMainWindow
 from PySide2.QtCore import QSize
 
 from gui.ui_dialog_od_view import Ui_ODView
+from gui.dialog_odme import DialogODME
 from od.od_matrix import ODMatrix
 
 from typing import Protocol
+
 
 class Model(Protocol):
     def estimate_od_fratar(self):
@@ -30,8 +32,14 @@ class DialogODView(QMainWindow):
 
         self.model = model
 
+        self.dialog_odme = DialogODME(model)
+
         self.ui.tabWidget.currentChanged.connect(self.tab_changed)
-        self.ui.actionFratar.triggered.connect(self.fratar_factor)
+
+        self.ui.actionODME_fratar.triggered.connect(self.odme_fratar_factor)
+        self.ui.actionODME_leastsq.triggered.connect(self.odme_leastsq)
+        self.ui.actionODME_cmaes.triggered.connect(self.odme_cmaes)
+        
 
     def load_od_data(self):
         self.ui.mv1.load_od_data(self.model.od_seed)
@@ -48,7 +56,13 @@ class DialogODView(QMainWindow):
         self.resize(QSize(self.size().width() + 1, self.size().height() + 1))
         self.resize(QSize(self.size().width() - 1, self.size().height() - 1))
 
-    def fratar_factor(self):
+    def odme_fratar_factor(self):
         self.model.estimate_od_fratar()
         self.ui.mv2.load_od_data(self.model.od_estimated)
         self.ui.mv3.load_od_data(self.model.od_diff)
+
+    def odme_leastsq(self):
+        pass
+
+    def odme_cmaes(self):
+        self.dialog_odme.show()

--- a/jodeln/gui/dialog_od_view.ui
+++ b/jodeln/gui/dialog_od_view.ui
@@ -74,13 +74,25 @@
     <property name="title">
      <string>Estimate OD</string>
     </property>
-    <addaction name="actionFratar"/>
+    <addaction name="actionODME_fratar"/>
+    <addaction name="actionODME_leastsq"/>
+    <addaction name="actionODME_cmaes"/>
    </widget>
    <addaction name="menuODME"/>
   </widget>
-  <action name="actionFratar">
+  <action name="actionODME_fratar">
    <property name="text">
     <string>Bi-proportional matrix factoring (Fratar Method)</string>
+   </property>
+  </action>
+  <action name="actionODME_cmaes">
+   <property name="text">
+    <string>CMA-ES Method</string>
+   </property>
+  </action>
+  <action name="actionODME_leastsq">
+   <property name="text">
+    <string>Least Squares Method</string>
    </property>
   </action>
  </widget>

--- a/jodeln/gui/dialog_odme.py
+++ b/jodeln/gui/dialog_odme.py
@@ -55,6 +55,7 @@ class DialogODME(QWidget):
         
         self.model.export_od(self.ui.leExportFolder.text())
         self.model.export_od_by_route(self.ui.leExportFolder.text())
+        self.close()
 
     def on_pbExportFolder_click(self) -> None:
         """Open a standard file dialog for selecting the export folder."""

--- a/jodeln/gui/mainwindow.py
+++ b/jodeln/gui/mainwindow.py
@@ -10,7 +10,6 @@ from gui.ui_mainwindow import Ui_MainWindow
 from gui import schematic_scene, od_tablemodel
 from gui.dialog_open import DialogOpen
 from gui.dialog_export import DialogExport
-from gui.dialog_odme import DialogODME
 from gui.dialog_od_view import DialogODView
 
 from typing import Protocol, TYPE_CHECKING
@@ -41,19 +40,16 @@ class MainWindow(QMainWindow):
         # Save persistent references to dialogs
         self.dialog_open = DialogOpen(self.model, cb_post_load=self.show_network)
         self.dialog_export = DialogExport(self.model)
-        self.dialog_odme = DialogODME(self.model)
         self.dialog_od_view = DialogODView(self.model)
 
         # Connect push buttons to slot functions
         self.ui.pbShowDialogOpen.clicked.connect(self.show_dialog_open)
         self.ui.pbShowExportDialog.clicked.connect(self.show_dialog_export)
-        self.ui.pbShowODEstimation.clicked.connect(self.show_dialog_odme)
         self.ui.pbODView.clicked.connect(self.show_dialog_od_view)
 
         # Disable buttons that should only be used after loading a network
         self.ui.pbShowExportDialog.setEnabled(False)
         self.ui.pbODView.setEnabled(False)
-        self.ui.pbShowODEstimation.setEnabled(False)
 
         # Setup graphics view
         self.schematic_scene = schematic_scene.SchematicScene()
@@ -78,12 +74,9 @@ class MainWindow(QMainWindow):
     def show_dialog_export(self) -> None:
         self.dialog_export.show()
 
-    def show_dialog_odme(self) -> None:
-        self.dialog_odme.show()
-
     def show_dialog_od_view(self) -> None:
-        self.dialog_od_view.show()
         self.dialog_od_view.load_od_data()
+        self.dialog_od_view.show()
 
 
     def show_network(self) -> None:
@@ -123,7 +116,6 @@ class MainWindow(QMainWindow):
 
         self.ui.pbShowExportDialog.setEnabled(True)
         self.ui.pbODView.setEnabled(True)
-        self.ui.pbShowODEstimation.setEnabled(True)
 
 
     def on_od_table_selection(self, selected, deselected) -> None:

--- a/jodeln/gui/mainwindow.ui
+++ b/jodeln/gui/mainwindow.ui
@@ -55,14 +55,7 @@
       <item>
        <widget class="QPushButton" name="pbODView">
         <property name="text">
-         <string>View OD</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbShowODEstimation">
-        <property name="text">
-         <string>OD Estimation</string>
+         <string>View and Estimate OD</string>
         </property>
        </widget>
       </item>

--- a/jodeln/gui/ui_dialog_od_view.py
+++ b/jodeln/gui/ui_dialog_od_view.py
@@ -20,8 +20,12 @@ class Ui_ODView(object):
         if not ODView.objectName():
             ODView.setObjectName(u"ODView")
         ODView.resize(819, 528)
-        self.actionFratar = QAction(ODView)
-        self.actionFratar.setObjectName(u"actionFratar")
+        self.actionODME_fratar = QAction(ODView)
+        self.actionODME_fratar.setObjectName(u"actionODME_fratar")
+        self.actionODME_cmaes = QAction(ODView)
+        self.actionODME_cmaes.setObjectName(u"actionODME_cmaes")
+        self.actionODME_leastsq = QAction(ODView)
+        self.actionODME_leastsq.setObjectName(u"actionODME_leastsq")
         self.centralwidget = QWidget(ODView)
         self.centralwidget.setObjectName(u"centralwidget")
         self.gridLayout_3 = QGridLayout(self.centralwidget)
@@ -75,7 +79,9 @@ class Ui_ODView(object):
         ODView.setMenuBar(self.menuBar)
 
         self.menuBar.addAction(self.menuODME.menuAction())
-        self.menuODME.addAction(self.actionFratar)
+        self.menuODME.addAction(self.actionODME_fratar)
+        self.menuODME.addAction(self.actionODME_leastsq)
+        self.menuODME.addAction(self.actionODME_cmaes)
 
         self.retranslateUi(ODView)
 
@@ -87,7 +93,9 @@ class Ui_ODView(object):
 
     def retranslateUi(self, ODView):
         ODView.setWindowTitle(QCoreApplication.translate("ODView", u"OD Matrix", None))
-        self.actionFratar.setText(QCoreApplication.translate("ODView", u"Bi-proportional matrix factoring (Fratar Method)", None))
+        self.actionODME_fratar.setText(QCoreApplication.translate("ODView", u"Bi-proportional matrix factoring (Fratar Method)", None))
+        self.actionODME_cmaes.setText(QCoreApplication.translate("ODView", u"CMA-ES Method", None))
+        self.actionODME_leastsq.setText(QCoreApplication.translate("ODView", u"Least Squares Method", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabSeed), QCoreApplication.translate("ODView", u"Seed Matrix", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabEst), QCoreApplication.translate("ODView", u"Estimated Matrix", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabDiff), QCoreApplication.translate("ODView", u"Diff Matrix", None))

--- a/jodeln/gui/ui_mainwindow.py
+++ b/jodeln/gui/ui_mainwindow.py
@@ -51,11 +51,6 @@ class Ui_MainWindow(object):
 
         self.horizontalLayout.addWidget(self.pbODView)
 
-        self.pbShowODEstimation = QPushButton(self.centralwidget)
-        self.pbShowODEstimation.setObjectName(u"pbShowODEstimation")
-
-        self.horizontalLayout.addWidget(self.pbShowODEstimation)
-
 
         self.verticalLayout_2.addLayout(self.horizontalLayout)
 
@@ -167,8 +162,7 @@ class Ui_MainWindow(object):
         MainWindow.setWindowTitle(QCoreApplication.translate("MainWindow", u"Jodeln", None))
         self.pbShowDialogOpen.setText(QCoreApplication.translate("MainWindow", u"Open", None))
         self.pbShowExportDialog.setText(QCoreApplication.translate("MainWindow", u"Export", None))
-        self.pbODView.setText(QCoreApplication.translate("MainWindow", u"View OD", None))
-        self.pbShowODEstimation.setText(QCoreApplication.translate("MainWindow", u"OD Estimation", None))
+        self.pbODView.setText(QCoreApplication.translate("MainWindow", u"View and Estimate OD", None))
         self.filterToggle.setText(QCoreApplication.translate("MainWindow", u"Filter", None))
         self.label.setText(QCoreApplication.translate("MainWindow", u"Origin", None))
         self.label_2.setText(QCoreApplication.translate("MainWindow", u"Destination", None))


### PR DESCRIPTION
This pull request does the following:

- Puts all the OD estimation methods into the OD view dialog.
- Adds a placeholder for Least Squares OD estimation method.

Still todo is the need to update the OD table view widgets and margin widgets after running an OD estimation. Current code is inconsistent or incomplete regarding OD view updates.